### PR TITLE
(Nucleus): allow access to private ECR repo in other regions than Gre…

### DIFF
--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
@@ -218,7 +218,11 @@ public class DockerImageDownloader extends ArtifactDownloader {
     }
 
 
+
+
     private String getRegionFromArtifactUri(String artifactUriStr) {
+        //get the actual region from the artifact uri
+
         String regionStr = "";
 
         if (!Utils.isEmpty(artifactUriStr)) {

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloader.java
@@ -17,6 +17,7 @@ import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.util.CrashableSupplier;
 import com.aws.greengrass.util.RetryUtils;
+import com.aws.greengrass.util.Utils;
 import lombok.AccessLevel;
 import lombok.Setter;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -161,8 +162,11 @@ public class DockerImageDownloader extends ArtifactDownloader {
                         // credentials for them on case by case basis
                         if (image.getRegistry().isEcrRegistry()) {
                             // Get auth token for ECR, which represents ECR registry credentials
+
+                            String actualRegion = getRegionFromArtifactUri(image.getArtifactUri().toString());
+
                             Registry.Credentials credentials =
-                                    ecrAccessor.getCredentials(image.getRegistry().getRegistryId());
+                                    ecrAccessor.getCredentials(image.getRegistry().getRegistryId(),actualRegion);
                             image.getRegistry().setCredentials(credentials);
                             credentialRefreshNeeded.set(false);
                         }
@@ -211,6 +215,24 @@ public class DockerImageDownloader extends ArtifactDownloader {
         } while (credentialRefreshNeeded.get());
         // No file resources available since image artifacts are stored in docker's image store
         return null;
+    }
+
+
+    private String getRegionFromArtifactUri(String artifactUriStr) {
+        String regionStr = "";
+
+        if (!Utils.isEmpty(artifactUriStr)) {
+            String[] arr = artifactUriStr.split("\\.");
+
+            for (int i = 0; i < arr.length; i++) {
+                if ("amazonaws".equalsIgnoreCase(arr[i])) {
+                    regionStr = arr[i - 1];
+                    break;
+                }
+            }
+        }
+
+        return regionStr;
     }
 
     /*

--- a/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessor.java
+++ b/src/main/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessor.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.tes.LazyCredentialProvider;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.ProxyUtils;
+import com.aws.greengrass.util.Utils;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ecr.EcrClient;
@@ -57,12 +58,17 @@ public class EcrAccessor {
         this.lazyCredentialProvider = null;
     }
 
-    private EcrClient getClient() {
+    private EcrClient getClient(String actualRegion) {
         if (injectedClient != null) {
             return injectedClient;
         }
+
+        if (Utils.isEmpty(actualRegion)) {
+            actualRegion = Coerce.toString(deviceConfiguration.getAWSRegion());
+        }
+
         return EcrClient.builder().httpClient(ProxyUtils.getSdkHttpClient())
-                .region(Region.of(Coerce.toString(deviceConfiguration.getAWSRegion())))
+                .region(Region.of(actualRegion))
                 .credentialsProvider(lazyCredentialProvider).build();
     }
 
@@ -70,12 +76,13 @@ public class EcrAccessor {
      * Get credentials(auth token) for a private docker registry in ECR.
      *
      * @param registryId Registry id
+     * @param actualRegion actual region
      * @return Registry.Credentials - Registry's authorization information
      * @throws RegistryAuthException When authentication fails
      */
     @SuppressWarnings("PMD.AvoidRethrowingException")
-    public Registry.Credentials getCredentials(String registryId) throws RegistryAuthException {
-        try (EcrClient client = getClient()) {
+    public Registry.Credentials getCredentials(String registryId,String actualRegion) throws RegistryAuthException {
+        try (EcrClient client = getClient(actualRegion)) {
             AuthorizationData authorizationData = client.getAuthorizationToken(
                     GetAuthorizationTokenRequest.builder().registryIds(Collections.singletonList(registryId)).build())
                     .authorizationData().get(0);

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/DockerImageDownloaderTest.java
@@ -90,7 +90,7 @@ public class DockerImageDownloaderTest {
                         + ".com/testimagepath/testimage@sha256:223057d6358a0530e4959c883e05199317cdc892f08667e6186133a0b5432948");
         Image image = Image.fromArtifactUri(ComponentArtifact.builder().artifactUri(artifactUri).build());
 
-        when(ecrAccessor.getCredentials("012345678910"))
+        when(ecrAccessor.getCredentials("012345678910",""))
                 .thenReturn(new Registry.Credentials("username", "password", Instant.now().plusSeconds(60)));
         when(dockerClient.dockerInstalled()).thenReturn(true);
 
@@ -106,7 +106,7 @@ public class DockerImageDownloaderTest {
         assertEquals("012345678910.dkr.ecr.us-east-1.amazonaws.com", image.getRegistry().getEndpoint());
         assertEquals("012345678910", image.getRegistry().getRegistryId());
 
-        verify(ecrAccessor).getCredentials("012345678910");
+        verify(ecrAccessor).getCredentials("012345678910","");
         verify(dockerClient).pullImage(image);
     }
 
@@ -115,7 +115,7 @@ public class DockerImageDownloaderTest {
             throws Exception {
         URI artifactUri = new URI("docker:012345678910.dkr.ecr.us-east-1.amazonaws.com/testimage:sometag");
         Image image = Image.fromArtifactUri(ComponentArtifact.builder().artifactUri(artifactUri).build());
-        when(ecrAccessor.getCredentials("012345678910"))
+        when(ecrAccessor.getCredentials("012345678910",""))
                 .thenReturn(new Registry.Credentials("username", "password", Instant.now().plusSeconds(60)));
         when(dockerClient.dockerInstalled()).thenReturn(true);
 
@@ -131,7 +131,7 @@ public class DockerImageDownloaderTest {
         assertEquals("012345678910.dkr.ecr.us-east-1.amazonaws.com", image.getRegistry().getEndpoint());
         assertEquals("012345678910", image.getRegistry().getRegistryId());
 
-        verify(ecrAccessor).getCredentials("012345678910");
+        verify(ecrAccessor).getCredentials("012345678910","");
         verify(dockerClient).pullImage(image);
     }
 
@@ -153,7 +153,7 @@ public class DockerImageDownloaderTest {
         assertFalse(image.getRegistry().isPrivateRegistry());
         assertEquals("public.ecr.aws", image.getRegistry().getEndpoint());
 
-        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(ecrAccessor, never()).getCredentials(anyString(),"");
         verify(dockerClient).pullImage(image);
         verify(dockerClient, never()).login(any());
     }
@@ -176,7 +176,7 @@ public class DockerImageDownloaderTest {
         assertFalse(image.getRegistry().isPrivateRegistry());
         assertEquals("registry.hub.docker.com", image.getRegistry().getEndpoint());
 
-        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(ecrAccessor, never()).getCredentials(anyString(),"");
         verify(dockerClient).pullImage(image);
     }
 
@@ -198,7 +198,7 @@ public class DockerImageDownloaderTest {
         assertFalse(image.getRegistry().isPrivateRegistry());
         assertEquals("registry.hub.docker.com", image.getRegistry().getEndpoint());
 
-        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(ecrAccessor, never()).getCredentials(anyString(),"");
         verify(dockerClient, never()).login(any());
         verify(dockerClient, never()).pullImage(any());
     }
@@ -226,7 +226,7 @@ public class DockerImageDownloaderTest {
         assertFalse(image.getRegistry().isPrivateRegistry());
         assertEquals("registry.hub.docker.com", image.getRegistry().getEndpoint());
 
-        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(ecrAccessor, never()).getCredentials(anyString(),"");
         verify(dockerClient, never()).login(any());
         verify(dockerClient).pullImage(image);
     }
@@ -236,7 +236,7 @@ public class DockerImageDownloaderTest {
             throws Exception {
         URI artifactUri = new URI("docker:012345678910.dkr.ecr.us-east-1.amazonaws.com/testimage:sometag");
         Image image = Image.fromArtifactUri(ComponentArtifact.builder().artifactUri(artifactUri).build());
-        when(ecrAccessor.getCredentials("012345678910"))
+        when(ecrAccessor.getCredentials("012345678910",""))
                 .thenThrow(new RegistryAuthException("Failed to get " + "credentials for ECR registry"));
         when(dockerClient.dockerInstalled()).thenReturn(true);
 
@@ -254,7 +254,7 @@ public class DockerImageDownloaderTest {
         assertEquals("012345678910.dkr.ecr.us-east-1.amazonaws.com", image.getRegistry().getEndpoint());
         assertEquals("012345678910", image.getRegistry().getRegistryId());
 
-        verify(ecrAccessor).getCredentials("012345678910");
+        verify(ecrAccessor).getCredentials("012345678910","");
         verify(dockerClient, never()).login(any());
         verify(dockerClient, never()).pullImage(any());
     }
@@ -283,7 +283,7 @@ public class DockerImageDownloaderTest {
         assertFalse(image.getRegistry().isPrivateRegistry());
         assertEquals("registry.hub.docker.com", image.getRegistry().getEndpoint());
 
-        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(ecrAccessor, never()).getCredentials(anyString(),"");
         verify(dockerClient, never()).login(any());
         // Invocations as many as the retry count should be expected
         verify(dockerClient, times(2)).pullImage(any());
@@ -317,7 +317,7 @@ public class DockerImageDownloaderTest {
         assertFalse(image.getRegistry().isPrivateRegistry());
         assertEquals("registry.hub.docker.com", image.getRegistry().getEndpoint());
 
-        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(ecrAccessor, never()).getCredentials(anyString(),"");
         verify(dockerClient, never()).login(any());
         // Invocations as many as the retry attempts should be expected
         verify(dockerClient, times(4)).pullImage(any());
@@ -348,7 +348,7 @@ public class DockerImageDownloaderTest {
         assertFalse(image.getRegistry().isPrivateRegistry());
         assertEquals("registry.hub.docker.com", image.getRegistry().getEndpoint());
 
-        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(ecrAccessor, never()).getCredentials(anyString(),"");
         verify(dockerClient, never()).login(any());
         // Invocations as many as the retry count should be expected
         verify(dockerClient, times(2)).pullImage(any());
@@ -380,7 +380,7 @@ public class DockerImageDownloaderTest {
         assertFalse(image.getRegistry().isPrivateRegistry());
         assertEquals("registry.hub.docker.com", image.getRegistry().getEndpoint());
 
-        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(ecrAccessor, never()).getCredentials(anyString(),"");
         verify(dockerClient, never()).login(any());
         // Invocations as many as the retry count should be expected
         verify(dockerClient, times(2)).pullImage(any());
@@ -393,7 +393,7 @@ public class DockerImageDownloaderTest {
         URI artifactUri = new URI("docker:012345678910.dkr.ecr.us-east-1.amazonaws.com/testimage:sometag");
         Image image = Image.fromArtifactUri(ComponentArtifact.builder().artifactUri(artifactUri).build());
         when(dockerClient.dockerInstalled()).thenReturn(true);
-        when(ecrAccessor.getCredentials("012345678910"))
+        when(ecrAccessor.getCredentials("012345678910",""))
                 .thenReturn(new Registry.Credentials("username", "password", Instant.now().plusSeconds(60)));
         doThrow(new UserNotAuthorizedForDockerException(
                 "Got permission denied while trying to connect to the Docker daemon socket")).when(dockerClient)
@@ -413,7 +413,7 @@ public class DockerImageDownloaderTest {
         assertEquals("012345678910.dkr.ecr.us-east-1.amazonaws.com", image.getRegistry().getEndpoint());
         assertEquals("012345678910", image.getRegistry().getRegistryId());
 
-        verify(ecrAccessor).getCredentials("012345678910");
+        verify(ecrAccessor).getCredentials("012345678910","");
         verify(dockerClient).login(any());
         verify(dockerClient, never()).pullImage(any());
     }
@@ -436,7 +436,7 @@ public class DockerImageDownloaderTest {
         assertFalse(image.getRegistry().isPrivateRegistry());
         assertEquals("registry.hub.docker.com/library", image.getRegistry().getEndpoint());
 
-        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(ecrAccessor, never()).getCredentials(anyString(),"");
         verify(dockerClient, never()).login(any());
         verify(dockerClient).pullImage(image);
     }
@@ -459,7 +459,7 @@ public class DockerImageDownloaderTest {
         assertFalse(image.getRegistry().isPrivateRegistry());
         assertEquals("registry.hub.docker.com/library", image.getRegistry().getEndpoint());
 
-        verify(ecrAccessor, never()).getCredentials(anyString());
+        verify(ecrAccessor, never()).getCredentials(anyString(),"");
         verify(dockerClient, never()).login(any());
         verify(dockerClient).pullImage(image);
     }
@@ -472,7 +472,7 @@ public class DockerImageDownloaderTest {
         // Use stale credentials in first login attempt to simulate credentials expiry due to device being offline
         // for longer than credential validity. For the second attempt, use the opposite to simulate login was
         // performed in time before credentials expired.
-        when(ecrAccessor.getCredentials("012345678910"))
+        when(ecrAccessor.getCredentials("012345678910",""))
                 .thenReturn(new Registry.Credentials("username", "password", Instant.now().minusSeconds(300)))
                 .thenReturn(new Registry.Credentials("username", "password", Instant.now().plusSeconds(300)));
         when(dockerClient.dockerInstalled()).thenReturn(true);
@@ -491,7 +491,7 @@ public class DockerImageDownloaderTest {
         assertEquals("012345678910", image.getRegistry().getRegistryId());
 
         // Getting credentials should be performed twice because the first time, credentials expired
-        verify(ecrAccessor, times(2)).getCredentials("012345678910");
+        verify(ecrAccessor, times(2)).getCredentials("012345678910","");
         verify(dockerClient).pullImage(image);
         verify(dockerClient).login(image.getRegistry());
     }

--- a/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessorTest.java
+++ b/src/test/java/com/aws/greengrass/componentmanager/plugins/docker/EcrAccessorTest.java
@@ -54,7 +54,7 @@ public class EcrAccessorTest {
                 GetAuthorizationTokenResponse.builder().authorizationData(authorizationData).build();
         when(ecrClient.getAuthorizationToken(any(GetAuthorizationTokenRequest.class))).thenReturn(response);
 
-        Registry.Credentials credentials = ecrAccessor.getCredentials("some_registry_id");
+        Registry.Credentials credentials = ecrAccessor.getCredentials("some_registry_id","");
 
         assertEquals("username", credentials.getUsername());
         assertEquals("password", credentials.getPassword());
@@ -67,7 +67,7 @@ public class EcrAccessorTest {
         EcrException ecrException = (EcrException) EcrException.builder().message("Something went wrong").build();
         when(ecrClient.getAuthorizationToken(any(GetAuthorizationTokenRequest.class))).thenThrow(ecrException);
 
-        Throwable err = assertThrows(RegistryAuthException.class, () -> ecrAccessor.getCredentials("some_registry_id"));
+        Throwable err = assertThrows(RegistryAuthException.class, () -> ecrAccessor.getCredentials("some_registry_id",""));
         assertThat(err.getMessage(), containsString("Failed to get credentials for ECR registry - some_registry_id"));
         assertThat(err.getCause(), is(instanceOf(EcrException.class)));
         verify(ecrClient).getAuthorizationToken(any(GetAuthorizationTokenRequest.class));


### PR DESCRIPTION
…engrass Core region #1048

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
- [ ] Updated or added new unit tests.
- [ ] Updated or added new integration tests.
- [ ] Updated or added new end-to-end tests.
- [ ] If my code makes a remote network call, it was tested with a proxy.

**Any additional information or context required to review the change:**

**Documentation Checklist:**
 - [ ] Updated the README if applicable.

**Compatibility Checklist:**
- [ ] I confirm that the change is backwards compatible.
- [ ] Any modification or deletion of public interfaces does not impact other plugin components.
- [ ] For external library version updates, I have reviewed its change logs and Nucleus does not consume 
  any deprecated method or type.

Refer to [Compatibility Guidelines](/COMPATIBILITY.md) for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
